### PR TITLE
Remove dependency on org.apache.cordova.device for obtaining platformId

### DIFF
--- a/gapreload.js
+++ b/gapreload.js
@@ -1,5 +1,5 @@
 /*jshint browser:true, devel:true */
-/*global device */
+/*global cordova */
 
 function getXML(path, callback) {
   var request = new XMLHttpRequest();
@@ -47,9 +47,8 @@ getXML('gapreload', function (config) {
     var serverOrigin = getOrigin(config.SERVER_HOST, config.SERVER_PORT);
     var contentPath = /\/www\/.+$/.exec(location)[0];
     return document.addEventListener('deviceready', function () {
-      var platform = device.platform.toLowerCase();
       // Use `replace` so that it won't break the Android back button.
-      location.replace(serverOrigin + platform + contentPath);
+      location.replace(serverOrigin + cordova.platformId + contentPath);
     }, false);
   }
   var liveReloadHost = config.LIVERELOAD_HOST || config.SERVER_HOST;

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,6 @@
   <license>MIT</license>
 
   <engines><engine name="cordova" version=">=3.2.0"/></engines>
-  <dependency id="org.apache.cordova.device"/>
   <dependency id="com.ququplay.websocket.WebSocket"
     url="https://github.com/mkuklis/phonegap-websocket"/>
   <preference name="SERVER_HOST"/>


### PR DESCRIPTION
Tested this as best I can, both with http:// origin and file:/// origin and confirmed the cordova.platformId string looks both available and set during that code execution.
